### PR TITLE
fix(i18n): update Hebrew translations for Markdown help text

### DIFF
--- a/public/languages/he/markdown.json
+++ b/public/languages/he/markdown.json
@@ -2,11 +2,12 @@
 	"bold": "טקסט מודגש",
 	"italic": "טקסט נטוי",
 	"list-item": "פריט רשימה",
+	"heading": "כותרת",
 	"strikethrough-text": "קו חוצה",
 	"code-text": "קוד",
 	"link-text": "טקסט קישור",
 	"link-url": "כתובת קישור",
 	"picture-text": "כיתוב בבעיות טעינה",
 	"picture-url": "כתובת תמונה",
-	"help-text": "הפורום עובד עם Markdown. להסבר מלא, [לחץ כאן](http://commonmark.org/help/)"
+	"help-text": "הפורום עובד עם Markdown. להסבר מלא <a href=\"http://commonmark.org/help/\" class=\"text-decoration-underline\">לחצו כאן</a>."
 }


### PR DESCRIPTION
This pull request updates the Hebrew translation file for Markdown in `public/languages/he/markdown.json`. The changes include adding a new translation for headings and modifying the help text to use an HTML anchor tag with an underline class instead of Markdown syntax.